### PR TITLE
Include in reports if someone supported the victim

### DIFF
--- a/app/assets/javascripts/home.js
+++ b/app/assets/javascripts/home.js
@@ -54,8 +54,12 @@ function initMap() {
 
 function bubbleContent(report){
   var content = report.description;
-  content += "<br /><strong>";
 
+  if(report.support){
+    content += '<br /><em>' + report.support + '</em>';
+  }
+
+  content += "<br /><strong>";
   if(report.name){
     content += report.name + ", ";
   }

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -32,6 +32,6 @@ class ReportsController < ApplicationController
     end
 
     def report_params
-      params.require(:report).permit(:lat, :lng, :time, :address, :description, :summary, :approved, :town, :postcode, :region, :country, :house, :street, :name )
+      params.require(:report).permit(:lat, :lng, :time, :address, :description, :summary, :approved, :town, :postcode, :region, :country, :house, :street, :name, :support )
     end
 end

--- a/app/views/admin/reports/_form.html.erb
+++ b/app/views/admin/reports/_form.html.erb
@@ -36,6 +36,11 @@
   </div>
 
   <div class="form-group">
+    <%= f.label :support %>
+    <%= f.text_area :support, class: 'form-control' %>
+  </div>
+
+  <div class="form-group">
     <%= f.label :time %>
     <%= f.date_field :time, class: 'form-control' %>
   </div>

--- a/app/views/admin/reports/index.html.erb
+++ b/app/views/admin/reports/index.html.erb
@@ -9,6 +9,7 @@
       <th>When</th>
       <th>Town</th>
       <th>Description</th>
+      <th>Support</th>
       <th>Approved</th>
       <th colspan="2"></th>
     </tr>
@@ -20,6 +21,7 @@
         <td><%= report.time.strftime("%d %B") %></td>
         <td><%= report.town %></td>
         <td><%= truncate(report.description, length: 100) %></td>
+        <td><%= truncate(report.support, length: 100) %></td>
         <td><%= report.approved %></td>
         <td><%= link_to 'Edit', edit_admin_report_path(report) %></td>
         <td><%= link_to 'Destroy', [:admin, report], method: :delete, data: { confirm: 'Are you sure?' } %></td>

--- a/app/views/reports/_form.html.erb
+++ b/app/views/reports/_form.html.erb
@@ -70,6 +70,12 @@
   <%= f.hidden_field :house %>
   <%= f.hidden_field :country %>
 
+  <p class="flow-text center">Tell us if someone spoke up against it, or offered support to the victim...</p>
+
+  <div class="field">
+    <%= f.text_area :support %>
+  </div>
+
   <div class='center-btn'>
     <button class="actions waves-effect waves-light btn-large submit-button">
       Create Report

--- a/app/views/reports/timeline.html.erb
+++ b/app/views/reports/timeline.html.erb
@@ -11,6 +11,11 @@
             <%= simple_format report.description %>
             </p>
           <% end %>
+          <% if report.support  %>
+            <p class='summary'><em>
+            <%= simple_format report.support %>
+            </em></p>
+          <% end %>
         </div>
         <div class="card-action">
           <div class='share-buttons'>

--- a/db/migrate/20160701125244_add_support_to_reports.rb
+++ b/db/migrate/20160701125244_add_support_to_reports.rb
@@ -1,0 +1,5 @@
+class AddSupportToReports < ActiveRecord::Migration[5.0]
+  def change
+    add_column :reports, :support, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160628222929) do
+ActiveRecord::Schema.define(version: 20160701125244) do
 
   create_table "pledges", force: :cascade do |t|
     t.string   "email"
@@ -37,6 +37,7 @@ ActiveRecord::Schema.define(version: 20160628222929) do
     t.string   "name"
     t.datetime "created_at",                                           null: false
     t.datetime "updated_at",                                           null: false
+    t.string   "support"
   end
 
 end


### PR DESCRIPTION
I wonder if positive messages about people being brave and standing up to
harassment might normalise that behaviour and encourage others to do the
same. This PR adds that question to the report form, and displays the
response on the homepage map, timeline and admin view.

I know every time I read these horrible reports, I wonder if someone
actually stepped in. I really hope I would, but I am sure I would feel
a bit braver knowing others have done the same.
