### PR TITLE
Add pledge to the top nav

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -33,6 +33,7 @@
         <li><%= link_to "Map", root_path %></li>
         <li><%= link_to "Timeline", timeline_reports_path %></li>
         <li><%= link_to "About", about_path %></li>
+        <li><%= link_to "Pledge", new_pledge_path %></li>
         <li><%= link_to "Report Incident", new_report_path, class: 'report' %></li>
       </ul>
 
@@ -40,6 +41,7 @@
         <li><%= link_to "Map", root_path %></li>
         <li><%= link_to "Timeline", timeline_reports_path %></li>
         <li><%= link_to "About", about_path %></li>
+        <li><%= link_to "Pledge", new_pledge_path %></li>
         <li><%= link_to "Report Incident", new_report_path, class: 'report' %></li>
       </ul>
     </nav>


### PR DESCRIPTION
Pledge is not currently linked from every page (though for many
users, that’s the primary action they can take on the site.)

Adding it to the top nav makes it available from every page. I.e.

Desktop:
![screen shot 2016-07-14 at 09 44 23](https://cloud.githubusercontent.com/assets/464193/16833532/abfabdea-49a7-11e6-9110-f036324b9d60.png)

Mobile:
![screen shot 2016-07-14 at 09 44 44](https://cloud.githubusercontent.com/assets/464193/16833538/b1885aec-49a7-11e6-9702-bf04e0583dd4.png)
